### PR TITLE
Inject current user as modifier from controller

### DIFF
--- a/lib/mongoid/history.rb
+++ b/lib/mongoid/history.rb
@@ -8,6 +8,7 @@ require 'mongoid/history/options'
 require 'mongoid/history/version'
 require 'mongoid/history/tracker'
 require 'mongoid/history/trackable'
+require 'mongoid/history/hooks'
 
 module Mongoid
   module History

--- a/lib/mongoid/history/hooks.rb
+++ b/lib/mongoid/history/hooks.rb
@@ -1,0 +1,22 @@
+module Current
+ thread_mattr_accessor :controller 
+end
+
+module Mongoid
+  module History
+    module Hooks
+      extend ActiveSupport::Concern
+
+      included do
+        before_action do |controller|
+          Current.controller = controller
+        end
+
+        # Need to ensure this with around_action
+        after_action do |controller|
+          Current.controller = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/mongoid/history/hooks.rb
+++ b/lib/mongoid/history/hooks.rb
@@ -8,13 +8,13 @@ module Mongoid
       extend ActiveSupport::Concern
 
       included do
-        before_action do |controller|
-          Current.controller = controller
-        end
-
-        # Need to ensure this with around_action
-        after_action do |controller|
-          Current.controller = nil
+        around_action do |controller, block|
+          begin
+            Current.controller = controller
+            block.call
+          ensure
+            Current.controller = nil
+          end
         end
       end
     end

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -235,7 +235,9 @@ module Mongoid
             association_chain: traverse_association_chain,
             scope: related_scope
           }
+
           @history_tracker_attributes[:modifier] = send(modifier_field) if modifier_field
+          @history_tracker_attributes[:modifier] = modifier_from_controller unless @history_tracker_attributes[:modifier]
 
           original, modified = transform_changes(modified_attributes_for_action(action))
 
@@ -254,6 +256,12 @@ module Mongoid
 
         def track_destroy(&block)
           track_history_for_action(:destroy, &block) unless destroyed?
+        end
+
+        def modifier_from_controller
+          return unless Current.controller && Current.controller.respond_to?(Mongoid::History.current_user_method, true)
+
+          Current.controller.send(Mongoid::History.current_user_method)
         end
 
         def clear_trackable_memoization

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -71,6 +71,9 @@ describe Mongoid::History do
 
     class Foo < Comment
     end
+
+    class Controller
+    end
   end
 
   after :each do
@@ -948,6 +951,15 @@ describe Mongoid::History do
         expect(sausage.history_tracks.last.action).to eq('destroy')
         sausage.history_tracks.last.undo! user
         expect(sausage.reload.flavour).to eq('Guinness')
+      end
+    end
+
+    describe 'controller defined modifier' do
+      it 'should save modifier' do
+        Current.controller = Controller.new
+        allow_any_instance_of(Controller).to receive(:current_user).and_return(user)
+
+        expect(post.history_tracks.last.modifier.id).to eq user.id
       end
     end
 


### PR DESCRIPTION
Mostly taken from - https://github.com/melnikaite/mongoid-history/tree/set_modifier_id but updated to use the rails 5 `thread_mattr_accessor`. Could downgrade this if we wanted to contribute back otherwise it adds a dependency on rails5